### PR TITLE
[FOIA22-103] Keep external link icon on documents list

### DIFF
--- a/js/components/foia_component_card.jsx
+++ b/js/components/foia_component_card.jsx
@@ -10,7 +10,13 @@ function Card({ card }) {
   } = card;
 
   return (
-    <a className={`foia-component-card ${alt ? 'foia-component-card--alt' : ''}`} href={url} onClick={onClick}>
+    <a
+      className={`foia-component-card ${
+        alt ? 'foia-component-card--alt foia-component-card--alt--ext' : ''
+      }`}
+      href={url}
+      onClick={onClick}
+    >
       <span className="foia-component-card__tag">{tag}</span>
       <h2 className="foia-component-card__title">{title}</h2>
       {subtitle && <span className="foia-component-card__subtitle">{subtitle}</span>}


### PR DESCRIPTION
Fix for: https://forumone.atlassian.net/browse/FOIA22-103?focusedCommentId=540488, in which the external link icon was no longer appearing on the documents list returned by the wizard results (add the same class that was applied to the summary links)

Merged to `buildkite`