### PR TITLE
Remove "The agency type-ahead works" and "The agency a-to-z list work…

### DIFF
--- a/features/Homepage.feature
+++ b/features/Homepage.feature
@@ -11,15 +11,3 @@ Feature: Homepage
 
   Scenario: The introduction banner appears on the page
     Then I should see "The basic function of the Freedom of Information Act"
-
-  Scenario: The agency type-ahead works
-    Then I should see "Search" in the "homepage search button" element
-    And I enter "OIP" into the homepage agency search box
-    Then I should see "In addition to its policy functions, OIP oversees agency compliance with the FOIA."
-
-  Scenario: The agency a-to-z list works
-    And I hard click on "the A-to-Z button"
-    And I hard click on "the A button"
-    And I hard click on "the last item in the A section"
-    And I wait 5 seconds
-    Then I should see "a premier retirement community with exceptional residential care"


### PR DESCRIPTION
…s" scenarios from the Homepage functional test.