### PR TITLE
[FOIA22-132] If agency match is most of the user's query, don't let the intent model hijack

### DIFF
--- a/js/components/wizard_page_intro.jsx
+++ b/js/components/wizard_page_intro.jsx
@@ -6,16 +6,16 @@ import Button from './wizard_component_button';
 import WizardHtml from './wizard_html';
 
 function Intro() {
-  const { actions, ready } = useWizard();
+  const { actions, introReady } = useWizard();
 
   return (
     <PageTemplate>
       <Constrain>
-        {!ready && (
+        {!introReady && (
           <WizardHtml mid="loading" />
         )}
 
-        {ready && (
+        {introReady && (
           <div className="w-component-intro">
             <WizardHtml mid="intro_slide" />
 

--- a/js/components/wizard_page_query.jsx
+++ b/js/components/wizard_page_query.jsx
@@ -12,13 +12,14 @@ const MAX_QUERY_LENGTH = 500;
 
 function Query() {
   const {
-    actions, allTopics, loading,
+    actions, allTopics,
   } = useWizard();
 
   const [query, setQuery] = useState(/** @type string | null */ null);
   const [exceededMaxLengthQuery, setExceededMaxLengthQuery] = useState(/** @type boolean */ false);
   const [selectedTopic, setSelectedTopic] = useState(/** @type WizardTopic | null */ null);
   const [modalIsOpen, setIsOpen] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
 
   const openModal = () => setIsOpen(true);
   const closeModal = () => setIsOpen(false);
@@ -87,15 +88,18 @@ function Query() {
         {(query && query !== '' && !exceededMaxLengthQuery) || selectedTopic ? (
           <div className="w-component-submit">
             <Button
-              onClick={() => actions.submitRequest({
-                query: query || '',
-                topic: selectedTopic,
-              })}
-              disabled={loading}
+              onClick={() => {
+                setSubmitted(true);
+                actions.submitRequest({
+                  query: query || '',
+                  topic: selectedTopic,
+                });
+              }}
+              disabled={submitted}
             >
               Submit
             </Button>
-            {loading && <WizardHtml mid="loading" />}
+            {submitted && <WizardHtml mid="loading" />}
           </div>
         ) : null}
       </Constrain>

--- a/js/components/wizard_page_summary.jsx
+++ b/js/components/wizard_page_summary.jsx
@@ -12,6 +12,7 @@ import NoResults from './wizard_component_no_results';
 import RichText from './wizard_component_rich_text';
 import WizardHtml from './wizard_html';
 
+const debug = true;
 const limit = parseInt(urlParams().get('limit') || '6', 10);
 
 function Summary() {
@@ -77,6 +78,10 @@ function Summary() {
       <WizardLinks links={links.slice(0, limit)} />
     </>
   );
+
+  if (hasTopicContent && debug) {
+    console.log('Since topic content is shown, model-provided agencies and docs are not displayed:', { agencies, links });
+  }
 
   return (
     <PageTemplate>

--- a/js/wizard-types.d.ts
+++ b/js/wizard-types.d.ts
@@ -127,7 +127,7 @@ declare global {
     next: WizardQuestion | WizardContinue | WizardSummary | WizardStartOver;
   };
 
-  type WizardHistorySnapshot = Omit<WizardVars, 'actions' | 'allTopics' | 'ui' | 'numLoading'>;
+  type WizardHistorySnapshot = Omit<WizardVars, 'actions' | 'allTopics' | 'ui' | 'modelLoading'>;
 
   type WizardActions = {
     initLoad: () => void;
@@ -153,12 +153,12 @@ declare global {
     answerIdx: number | null;
     displayedTopic: string;
     isError: boolean;
-    flatList: FlatListItem[];
-    numLoading: number;
+    flatList: FlatListItem[] | null;
+    modelLoading: boolean;
     query: string | null;
-    ready: boolean;
     recommendedAgencies: WizardAgency[] | null;
     recommendedLinks: WizardLink[] | null;
+    triggerPhrases: WizardTriggerPhrase[] | null;
     ui: Record<string, string>;
     userTopic: WizardTopic | null;
   };

--- a/www.foia.gov/wizard.html
+++ b/www.foia.gov/wizard.html
@@ -5,29 +5,26 @@ bundle: wizard
 ---
 <div id="wizard-react-app">
     <!-- Initial content to be replaced by React. Update as necessary -->
-    <div class="w-layout-app-container">
+    <div class="w-layout-app-container" id="main">
         <header class="w-layout-header">
             <div class="w-layout-header__upper">
                 <div class="w-layout-constrain w-layout-constrain--large">
-                    <div class="w-component-logo usa-logo">
-                        <a class="w-component-logo__link" href="/" accesskey="1" title="Home">
-                            <img class="w-component-logo__image" src="/img/foia-doj-logo-light.svg" alt="Foia.gov">
-                            <h1 class="w-component-logo__text usa-header-title">FOIA.gov</h1>
-                        </a>
-                    </div>
+                    <div class="w-component-logo usa-logo"><a class="w-component-logo__link" href="/" accesskey="1"
+                                                              title="Home"><img class="w-component-logo__image"
+                                                                                src="/img/foia-doj-logo-light.svg"
+                                                                                alt="Foia.gov">
+                        <h1 class="w-component-logo__text usa-header-title">FOIA.gov</h1></a></div>
                 </div>
             </div>
             <div class="w-layout-header__lower">
-                <div class="w-layout-constrain w-layout-constrain--large">
-                    <a class="w-component-back-link" href="/">Home</a>
+                <div class="w-layout-constrain w-layout-constrain--large"><a class="w-component-back-link"
+                                                                             href="/">Home</a>
                 </div>
             </div>
         </header>
-        <div class="w-layout-constrain" id="main">
-            <div class="w-component-rich-text">
-                <p>Loading...</p>
-
-            </div>
+        <div class="w-layout-constrain">
+            <div class="w-component-rich-text" data-mid="loading"><p>Loading...</p></div>
         </div>
     </div>
 </div>
+


### PR DESCRIPTION
Also adds debugging to console.

**Track loading state more granularly, allow submitting before agencies loaded**
We don't need the agencies to have loaded to let the user proceed to enter
their query. Instead the submit action waits--if necessary--for the agency
data to load completely.

I also convert default array states to null, because it's clearer to detect.
I was wrong about this earlier.

**Update the default UI before the react app can load and render**

https://forumone.atlassian.net/browse/FOIA22-132