### PR TITLE
[FOIA22-146] Move the common topics above the search box on the query page

### DIFF
--- a/js/components/wizard_component_pill_group.jsx
+++ b/js/components/wizard_component_pill_group.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Pill from './wizard_component_pill';
+import Heading from './wizard_component_heading';
 
 /**
  * @param {Object} props
@@ -22,7 +23,7 @@ function PillGroup({
     return (
       <div className="w-component-pill-group">
         {label && (
-          <div className="w-component-pill-group__label">{label}</div>
+          <Heading tag="h2" className="w-component-pill-group__label">{label}</Heading>
         )}
         <ul className="w-component-pill-group__list">
           {topics.map((topic) => (

--- a/js/components/wizard_page_query.jsx
+++ b/js/components/wizard_page_query.jsx
@@ -48,21 +48,39 @@ function Query() {
     setSelectedTopic(isTopicSelected(topic) ? null : topic);
   }
 
+  const submitButton = (
+    <div className="w-component-submit">
+      <Button
+        onClick={() => {
+          setSubmitted(true);
+          actions.submitRequest({
+            query: query || '',
+            topic: selectedTopic,
+          });
+        }}
+        disabled={submitted}
+      >
+        Submit
+      </Button>
+      {submitted && <WizardHtml mid="loading" />}
+    </div>
+  );
+
   return (
     <PageTemplate>
       <Constrain>
         <WizardHtml mid="query_slide_1" />
         <PillGroup
-            label="Select a common topic"
-            topics={displayedTopics}
-            isTopicSelected={isTopicSelected}
-            onClickTopicButton={onClickTopicButton}
-            suffix={allTopics.length > 10 ? (
-              <button onClick={openModal} className="button-as-link" style={{ color: '#fff' }}>
-                See all
-              </button>
-            ) : null}
-          />
+          label="Select a common topic"
+          topics={displayedTopics}
+          isTopicSelected={isTopicSelected}
+          onClickTopicButton={onClickTopicButton}
+          suffix={allTopics.length > 10 ? (
+            <button onClick={openModal} className="button-as-link" style={{ color: '#fff' }}>
+              See all
+            </button>
+          ) : null}
+        />
         <Modal
           title="Common topics"
           contentLabel="All topics"
@@ -75,55 +93,32 @@ function Query() {
             onClickTopicButton={onClickTopicButton}
           />
         </Modal>
-        {selectedTopic ?
-          <SubmitButton
-            setSubmitted={setSubmitted}
-            submitRequest={actions.submitRequest}
-            query={query}
-            selectedTopic={selectedTopic}
-            submitted={submitted}
-          /> : null}
+        {selectedTopic ? submitButton : null}
 
-        <Heading tag="h2">Or search for something else</Heading>
-        <WizardHtml mid="query_slide_2" />
-        {exceededMaxLengthQuery && <p style={{ color: 'white' }}>Query is limited to 500 characters</p>}
-        {(query && query !== '' && !exceededMaxLengthQuery) ?
-          <SubmitButton
-            setSubmitted={setSubmitted}
-            submitRequest={actions.submitRequest}
-            query={query}
-            selectedTopic={selectedTopic}
-            submitted={submitted}
-          /> : null}
-        <FormItem
-          type="textarea"
-          isLabelHidden
-          label="Query"
-          onChange={(e) => setQuery(e.target.value)}
-          value={query || ''}
-          disabled={Boolean(selectedTopic)}
-        />
+        <div style={{
+          opacity: selectedTopic ? 0.5 : 1,
+          transition: 'opacity 1s',
+          paddingTop: '2rem',
+        }}
+        >
+          <Heading tag="h2">Or search for something else</Heading>
+          <WizardHtml mid="query_slide_2" />
+
+          {exceededMaxLengthQuery && <p style={{ color: 'white' }}>Query is limited to 500 characters</p>}
+          <FormItem
+            type="textarea"
+            isLabelHidden
+            label="Query"
+            onChange={(e) => setQuery(e.target.value)}
+            value={query || ''}
+            disabled={Boolean(selectedTopic)}
+          />
+
+          {(query && query !== '' && !exceededMaxLengthQuery) ? submitButton : null}
+        </div>
       </Constrain>
     </PageTemplate>
   );
-}
-
-function SubmitButton({ setSubmitted, submitRequest, query, selectedTopic, submitted }) {
-  return <div className="w-component-submit">
-    <Button
-      onClick={() => {
-        setSubmitted(true);
-        submitRequest({
-          query: query || '',
-          topic: selectedTopic,
-        });
-      }}
-      disabled={submitted}
-    >
-      Submit
-    </Button>
-    {submitted && <WizardHtml mid="loading" />}
-  </div>
 }
 
 export default Query;

--- a/js/components/wizard_page_query.jsx
+++ b/js/components/wizard_page_query.jsx
@@ -108,7 +108,7 @@ function Query() {
   );
 }
 
-function SubmitButton(setSubmitted, submitRequest, query, selectedTopic, submitted) {
+function SubmitButton({ setSubmitted, submitRequest, query, selectedTopic, submitted }) {
   return <div className="w-component-submit">
     <Button
       onClick={() => {

--- a/js/components/wizard_page_query.jsx
+++ b/js/components/wizard_page_query.jsx
@@ -7,6 +7,7 @@ import FormItem from './wizard_component_form_item';
 import Modal from './wizard_component_modal';
 import Constrain from './wizard_layout_constrain';
 import Button from './wizard_component_button';
+import Heading from './wizard_component_heading';
 
 const MAX_QUERY_LENGTH = 500;
 
@@ -50,26 +51,18 @@ function Query() {
   return (
     <PageTemplate>
       <Constrain>
-        <WizardHtml mid="query_slide" />
-        <FormItem
-          type="textarea"
-          isLabelHidden
-          label="Query"
-          onChange={(e) => setQuery(e.target.value)}
-          value={query || ''}
-          disabled={Boolean(selectedTopic)}
-        />
+        <WizardHtml mid="query_slide_1" />
         <PillGroup
-          label="Or choose a common topic"
-          topics={displayedTopics}
-          isTopicSelected={isTopicSelected}
-          onClickTopicButton={onClickTopicButton}
-          suffix={allTopics.length > 10 ? (
-            <button onClick={openModal} className="button-as-link" style={{ color: '#fff' }}>
-              See all
-            </button>
-          ) : null}
-        />
+            label="Select a common topic"
+            topics={displayedTopics}
+            isTopicSelected={isTopicSelected}
+            onClickTopicButton={onClickTopicButton}
+            suffix={allTopics.length > 10 ? (
+              <button onClick={openModal} className="button-as-link" style={{ color: '#fff' }}>
+                See all
+              </button>
+            ) : null}
+          />
         <Modal
           title="Common topics"
           contentLabel="All topics"
@@ -82,28 +75,55 @@ function Query() {
             onClickTopicButton={onClickTopicButton}
           />
         </Modal>
+        {selectedTopic ?
+          <SubmitButton
+            setSubmitted={setSubmitted}
+            submitRequest={actions.submitRequest}
+            query={query}
+            selectedTopic={selectedTopic}
+            submitted={submitted}
+          /> : null}
 
+        <Heading tag="h2">Or search for something else</Heading>
+        <WizardHtml mid="query_slide_2" />
         {exceededMaxLengthQuery && <p style={{ color: 'white' }}>Query is limited to 500 characters</p>}
-        {(query && query !== '' && !exceededMaxLengthQuery) || selectedTopic ? (
-          <div className="w-component-submit">
-            <Button
-              onClick={() => {
-                setSubmitted(true);
-                actions.submitRequest({
-                  query: query || '',
-                  topic: selectedTopic,
-                });
-              }}
-              disabled={submitted}
-            >
-              Submit
-            </Button>
-            {submitted && <WizardHtml mid="loading" />}
-          </div>
-        ) : null}
+        {(query && query !== '' && !exceededMaxLengthQuery) ?
+          <SubmitButton
+            setSubmitted={setSubmitted}
+            submitRequest={actions.submitRequest}
+            query={query}
+            selectedTopic={selectedTopic}
+            submitted={submitted}
+          /> : null}
+        <FormItem
+          type="textarea"
+          isLabelHidden
+          label="Query"
+          onChange={(e) => setQuery(e.target.value)}
+          value={query || ''}
+          disabled={Boolean(selectedTopic)}
+        />
       </Constrain>
     </PageTemplate>
   );
+}
+
+function SubmitButton(setSubmitted, submitRequest, query, selectedTopic, submitted) {
+  return <div className="w-component-submit">
+    <Button
+      onClick={() => {
+        setSubmitted(true);
+        submitRequest({
+          query: query || '',
+          topic: selectedTopic,
+        });
+      }}
+      disabled={submitted}
+    >
+      Submit
+    </Button>
+    {submitted && <WizardHtml mid="loading" />}
+  </div>
 }
 
 export default Query;

--- a/js/stores/wizard_store.js
+++ b/js/stores/wizard_store.js
@@ -163,7 +163,8 @@ const useRawWizardStore = create((
       ...extraMessages,
 
       intro_slide: data.language[lang].intro_slide,
-      query_slide: data.language[lang].query_slide,
+      query_slide_1: data.language[lang].query_slide_1,
+      query_slide_2: data.language[lang].query_slide_2,
       ...data.language[lang].messages,
     };
     set({ ui, triggerPhrases });

--- a/www.foia.gov/_sass/theme/_wizard_page.scss
+++ b/www.foia.gov/_sass/theme/_wizard_page.scss
@@ -225,8 +225,9 @@ $icon-chevron-left: '/img/icon-chevron-left.svg';
 // Heading Component
 .w-component-heading {
   color: $color-white;
-  font-size: 60px;
+  font-size: 30px;
   font-weight: 400;
+  margin-top: 0;
 }
 
 // Button Component
@@ -301,10 +302,11 @@ $icon-chevron-left: '/img/icon-chevron-left.svg';
 }
 
 .w-component-pill-group__label {
+  // where else is this used? If only here, make it a little smaller
   color: $color-white;
-  display: inline;
-  font-size: 18px;
+  font-size: 30px;
   margin-right: 30px;
+  margin-top: 0;
 }
 
 .w-component-pill-group__list {
@@ -424,7 +426,7 @@ $icon-chevron-left: '/img/icon-chevron-left.svg';
   p,
   li,
   blockquote {
-    font-size: 28px;
+    font-size: 20px;
     font-weight: 500;
     line-height: 1.2;
   }

--- a/www.foia.gov/_sass/theme/_wizard_page.scss
+++ b/www.foia.gov/_sass/theme/_wizard_page.scss
@@ -298,7 +298,7 @@ $icon-chevron-left: '/img/icon-chevron-left.svg';
 
 // Pill Group Component
 .w-component-pill-group {
-  margin-bottom: 3rem;
+  margin-bottom: 1rem;
 }
 
 .w-component-pill-group__label {


### PR DESCRIPTION
- Divide the query slide text
- Common topics move above the search query
- H2 style for “Select a common topic” and “Or search for something else”
- Reduce font size on search instructions to fit everything into the page w/o scrolling
- Submit button should move up under common topics if one is selected

For https://forumone.atlassian.net/browse/FOIA22-146
Merged to `buildkite`