### PR TITLE
[FOIA22-148] Display user's original query when bypassing a pre-set journey if there was a new displayed topic

### DIFF
--- a/js/components/wizard_page_summary.jsx
+++ b/js/components/wizard_page_summary.jsx
@@ -89,11 +89,11 @@ function Summary() {
           <h1><WizardHtml mid="lookingFor" /></h1>
           <blockquote>
             &ldquo;
-            {displayedTopic || request.query}
+            {showModelResults ? request.query : (displayedTopic || request.query)}
             &rdquo;
           </blockquote>
 
-          {Boolean(activity.titleMid) && (
+          {Boolean(activity.titleMid) && !showModelResults && (
             <WizardHtml mid={activity.titleMid} isSummaryAdvice />
           )}
 
@@ -102,21 +102,9 @@ function Summary() {
           {showModelResults && (
             // Show agencies & links from model
             <>
-              {!canSwitchToModelResults && displayedTopic && (
-                <>
-                  {/* If we're showing a journey message AND model results, and there's a "displayed topic" from a pre-set user journey, repeat the user's query here, since it will no longer be displayed above */}
-                  <h2><WizardHtml mid="lookedFor" /></h2>
-                  <blockquote>
-                    &ldquo;
-                    {request.query}
-                    &rdquo;
-                  </blockquote>
-                </>
-              )}
               {!hasLinks && !hasAgencies && (
                 <NoResults />
               )}
-
               {agenciesFirst && hasAgencies && agencySection}
               {hasLinks && linksSection}
               {!agenciesFirst && hasAgencies && agencySection}

--- a/js/components/wizard_page_summary.jsx
+++ b/js/components/wizard_page_summary.jsx
@@ -102,6 +102,17 @@ function Summary() {
           {showModelResults && (
             // Show agencies & links from model
             <>
+              {!canSwitchToModelResults && displayedTopic && (
+                <>
+                  {/* If we're showing a journey message AND model results, and there's a "displayed topic" from a pre-set user journey, repeat the user's query here, since it will no longer be displayed above */}
+                  <h2><WizardHtml mid="lookedFor" /></h2>
+                  <blockquote>
+                    &ldquo;
+                    {request.query}
+                    &rdquo;
+                  </blockquote>
+                </>
+              )}
               {!hasLinks && !hasAgencies && (
                 <NoResults />
               )}

--- a/js/models/wizard_extra_messages.js
+++ b/js/models/wizard_extra_messages.js
@@ -43,6 +43,7 @@ const extraMessages = {
   apiError: '<p>There was an error, please try again later.</p>',
   loading: '<p>Loading...</p>',
   lookingFor: 'Okay, you’re looking for:',
+  lookedFor: 'Your original query was:',
   soundsGood: 'Sounds good.',
   youSelected: 'You selected:',
   startOver: 'None of the above (I want to start over)',

--- a/js/models/wizard_extra_messages.js
+++ b/js/models/wizard_extra_messages.js
@@ -43,7 +43,6 @@ const extraMessages = {
   apiError: '<p>There was an error, please try again later.</p>',
   loading: '<p>Loading...</p>',
   lookingFor: 'Okay, you’re looking for:',
-  lookedFor: 'Your original query was:',
   soundsGood: 'Sounds good.',
   youSelected: 'You selected:',
   startOver: 'None of the above (I want to start over)',

--- a/js/stores/wizard_store.js
+++ b/js/stores/wizard_store.js
@@ -398,15 +398,10 @@ const useRawWizardStore = create((
   };
 
   const switchToModelResults = () => {
-    if (get().activity.type === 'summary') {
-      // Don't leave page, just show more
-      set({ showModelResults: true });
-    } else {
-      set(withCapturedHistory({
-        activity: { type: 'summary' },
-        showModelResults: true,
-      }));
-    }
+    set(withCapturedHistory({
+      activity: { type: 'summary' },
+      showModelResults: true,
+    }));
   };
 
   /** @type {WizardActions['selectAnswer']} */


### PR DESCRIPTION
For: https://forumone.atlassian.net/browse/FOIA22-148?focusedCommentId=551115

- When user bypasses the pre-set user journey, always just display their original query on the summary page
- Bypassing the pre-set user journey takes the user to the summary page, with the model results in place of the pre-set content

Merged to `buildkite`