### PR TITLE
[FOIA22-150] Agency Search page always return to top of page when switching pages

### DIFF
--- a/js/components/agency_search.jsx
+++ b/js/components/agency_search.jsx
@@ -90,6 +90,15 @@ function AgencySearch({
   const cardsPerPage = 18;
 
   useEffect(() => {
+    // Scroll to top whenever page changes
+    try {
+      window.scrollTo({ top: 0, behavior: 'instant' });
+    } catch (err) {
+      // NOOP
+    }
+  }, [currentPage]);
+
+  useEffect(() => {
     if (flatList.length) {
       if (search) {
         bloodhound.search(search, (filtered) => {


### PR DESCRIPTION
For: https://forumone.atlassian.net/browse/FOIA22-150
Merged to `buildkite`