### PR TITLE
[FOIA22-167] Configure for API updates

### DIFF
--- a/js/settings/cloud-gov.js
+++ b/js/settings/cloud-gov.js
@@ -2,7 +2,9 @@ const api = {
   localApiBaseURL: '/api',
   jsonApiBaseURL: 'https://dev-api.foia.gov/api',
   requestApiBaseURL: 'https://dev-api.foia.gov/api',
-  wizardApiURL: 'https://dev-api.foia.gov/doj-foia/models/ZBA2ow0/predict',
+  polydeltaProxyOrigin: 'https://dev-api.foia.gov',
+  // keyof POLYDELTA_APIS in /js/util/wizard_api.js
+  polydeltaApiVersion: 'v1_1',
   // These are not secret, refer to https://github.com/18F/beta.foia.gov/tree/develop/docs/foia-api.md
   apiProxyKey: '7aT5REJTpzjKoYKFuc9YIJLalHdYaif6ZqGkDPxG',
   jsonApiKey: '7aT5REJTpzjKoYKFuc9YIJLalHdYaif6ZqGkDPxG',

--- a/js/settings/cloud-gov.js
+++ b/js/settings/cloud-gov.js
@@ -4,7 +4,7 @@ const api = {
   requestApiBaseURL: 'https://dev-api.foia.gov/api',
   polydeltaProxyOrigin: 'https://dev-api.foia.gov',
   // keyof POLYDELTA_APIS in /js/util/wizard_api.js
-  polydeltaApiVersion: 'v1_1',
+  polydeltaApiVersion: 'v2_0beta',
   // These are not secret, refer to https://github.com/18F/beta.foia.gov/tree/develop/docs/foia-api.md
   apiProxyKey: '7aT5REJTpzjKoYKFuc9YIJLalHdYaif6ZqGkDPxG',
   jsonApiKey: '7aT5REJTpzjKoYKFuc9YIJLalHdYaif6ZqGkDPxG',

--- a/js/settings/ddev.js
+++ b/js/settings/ddev.js
@@ -2,7 +2,9 @@ const api = {
   localApiBaseURL: '/api',
   jsonApiBaseURL: 'https://foia-api.ddev.site/api',
   requestApiBaseURL: 'https://foia-api.ddev.site/api',
-  wizardApiURL: 'https://uat-api.foia.gov/doj-foia/models/ZBA2ow0/predict',
+  polydeltaProxyOrigin: 'https://uat-api.foia.gov',
+  // keyof POLYDELTA_APIS in /js/util/wizard_api.js
+  polydeltaApiVersion: 'v1_1',
   // These are not secret, refer to https://github.com/18F/beta.foia.gov/tree/develop/docs/foia-api.md
   apiProxyKey: 'PvO2Wh2UppBQqGIxIvdKbogNRI0W0MVLFhkxjWfK',
   jsonApiKey: 'local-not-needed',

--- a/js/settings/ddev.js
+++ b/js/settings/ddev.js
@@ -4,7 +4,7 @@ const api = {
   requestApiBaseURL: 'https://foia-api.ddev.site/api',
   polydeltaProxyOrigin: 'https://uat-api.foia.gov',
   // keyof POLYDELTA_APIS in /js/util/wizard_api.js
-  polydeltaApiVersion: 'v1_1',
+  polydeltaApiVersion: 'v2_0beta',
   // These are not secret, refer to https://github.com/18F/beta.foia.gov/tree/develop/docs/foia-api.md
   apiProxyKey: 'PvO2Wh2UppBQqGIxIvdKbogNRI0W0MVLFhkxjWfK',
   jsonApiKey: 'local-not-needed',

--- a/js/settings/development.js
+++ b/js/settings/development.js
@@ -2,7 +2,9 @@ const api = {
   localApiBaseURL: '/api',
   jsonApiBaseURL: 'https://dev-api.foia.gov/api',
   requestApiBaseURL: 'https://dev-api.foia.gov/api',
-  wizardApiURL: 'https://dev-api.foia.gov/doj-foia/models/ZBA2ow0/predict',
+  polydeltaProxyOrigin: 'https://dev-api.foia.gov',
+  // keyof POLYDELTA_APIS in /js/util/wizard_api.js
+  polydeltaApiVersion: 'v1_1',
   // These are not secret, refer to https://github.com/18F/beta.foia.gov/tree/develop/docs/foia-api.md
   apiProxyKey: '7aT5REJTpzjKoYKFuc9YIJLalHdYaif6ZqGkDPxG',
   jsonApiKey: '7aT5REJTpzjKoYKFuc9YIJLalHdYaif6ZqGkDPxG',

--- a/js/settings/development.js
+++ b/js/settings/development.js
@@ -4,7 +4,7 @@ const api = {
   requestApiBaseURL: 'https://dev-api.foia.gov/api',
   polydeltaProxyOrigin: 'https://dev-api.foia.gov',
   // keyof POLYDELTA_APIS in /js/util/wizard_api.js
-  polydeltaApiVersion: 'v1_1',
+  polydeltaApiVersion: 'v2_0beta',
   // These are not secret, refer to https://github.com/18F/beta.foia.gov/tree/develop/docs/foia-api.md
   apiProxyKey: '7aT5REJTpzjKoYKFuc9YIJLalHdYaif6ZqGkDPxG',
   jsonApiKey: '7aT5REJTpzjKoYKFuc9YIJLalHdYaif6ZqGkDPxG',

--- a/js/settings/forum-one.js
+++ b/js/settings/forum-one.js
@@ -4,7 +4,7 @@ const api = {
   requestApiBaseURL: 'https://api.main-bvxea6i-oafzps2pqxjxw.us-2.platformsh.site/api',
   polydeltaProxyOrigin: 'https://uat-api.foia.gov',
   // keyof POLYDELTA_APIS in /js/util/wizard_api.js
-  polydeltaApiVersion: 'v1_1',
+  polydeltaApiVersion: 'v2_0beta',
   // These are not secret, refer to https://github.com/18F/beta.foia.gov/tree/develop/docs/foia-api.md
   apiProxyKey: '7aT5REJTpzjKoYKFuc9YIJLalHdYaif6ZqGkDPxG',
   jsonApiKey: '7aT5REJTpzjKoYKFuc9YIJLalHdYaif6ZqGkDPxG',

--- a/js/settings/forum-one.js
+++ b/js/settings/forum-one.js
@@ -2,7 +2,9 @@ const api = {
   localApiBaseURL: '/api',
   jsonApiBaseURL: 'https://api.main-bvxea6i-oafzps2pqxjxw.us-2.platformsh.site/api',
   requestApiBaseURL: 'https://api.main-bvxea6i-oafzps2pqxjxw.us-2.platformsh.site/api',
-  wizardApiURL: 'https://uat-api.foia.gov/doj-foia/models/ZBA2ow0/predict',
+  polydeltaProxyOrigin: 'https://uat-api.foia.gov',
+  // keyof POLYDELTA_APIS in /js/util/wizard_api.js
+  polydeltaApiVersion: 'v1_1',
   // These are not secret, refer to https://github.com/18F/beta.foia.gov/tree/develop/docs/foia-api.md
   apiProxyKey: '7aT5REJTpzjKoYKFuc9YIJLalHdYaif6ZqGkDPxG',
   jsonApiKey: '7aT5REJTpzjKoYKFuc9YIJLalHdYaif6ZqGkDPxG',

--- a/js/settings/local.js
+++ b/js/settings/local.js
@@ -2,7 +2,9 @@ const api = {
   localApiBaseURL: '/api',
   jsonApiBaseURL: 'http://local-api.foia.doj.gov/api',
   requestApiBaseURL: 'http://local-api.foia.doj.gov/api',
-  wizardApiURL: 'https://uat-api.foia.gov/doj-foia/models/ZBA2ow0/predict',
+  polydeltaProxyOrigin: 'https://uat-api.foia.gov',
+  // keyof POLYDELTA_APIS in /js/util/wizard_api.js
+  polydeltaApiVersion: 'v1_1',
   // These are not secret, refer to https://github.com/18F/beta.foia.gov/tree/develop/docs/foia-api.md
   apiProxyKey: 'PvO2Wh2UppBQqGIxIvdKbogNRI0W0MVLFhkxjWfK',
   jsonApiKey: 'local-not-needed',

--- a/js/settings/local.js
+++ b/js/settings/local.js
@@ -4,7 +4,7 @@ const api = {
   requestApiBaseURL: 'http://local-api.foia.doj.gov/api',
   polydeltaProxyOrigin: 'https://uat-api.foia.gov',
   // keyof POLYDELTA_APIS in /js/util/wizard_api.js
-  polydeltaApiVersion: 'v1_1',
+  polydeltaApiVersion: 'v2_0beta',
   // These are not secret, refer to https://github.com/18F/beta.foia.gov/tree/develop/docs/foia-api.md
   apiProxyKey: 'PvO2Wh2UppBQqGIxIvdKbogNRI0W0MVLFhkxjWfK',
   jsonApiKey: 'local-not-needed',

--- a/js/settings/production.js
+++ b/js/settings/production.js
@@ -4,7 +4,7 @@ const api = {
   requestApiBaseURL: 'https://api.foia.gov/api',
   polydeltaProxyOrigin: 'https://api.foia.gov',
   // keyof POLYDELTA_APIS in /js/util/wizard_api.js
-  polydeltaApiVersion: 'v1_1',
+  polydeltaApiVersion: 'v2_0',
   // These are not secret, refer to https://github.com/18F/beta.foia.gov/tree/develop/docs/foia-api.md
   apiProxyKey: 'mUPoczW5VDRQOvroK6srQIjEGc5xBP0KDHgE34fv',
   jsonApiKey: 'mUPoczW5VDRQOvroK6srQIjEGc5xBP0KDHgE34fv',

--- a/js/settings/production.js
+++ b/js/settings/production.js
@@ -2,7 +2,9 @@ const api = {
   localApiBaseURL: '/api',
   jsonApiBaseURL: 'https://api.foia.gov/api',
   requestApiBaseURL: 'https://api.foia.gov/api',
-  wizardApiURL: 'https://api.foia.gov/doj-foia/models/ZBA2ow0/predict',
+  polydeltaProxyOrigin: 'https://api.foia.gov',
+  // keyof POLYDELTA_APIS in /js/util/wizard_api.js
+  polydeltaApiVersion: 'v1_1',
   // These are not secret, refer to https://github.com/18F/beta.foia.gov/tree/develop/docs/foia-api.md
   apiProxyKey: 'mUPoczW5VDRQOvroK6srQIjEGc5xBP0KDHgE34fv',
   jsonApiKey: 'mUPoczW5VDRQOvroK6srQIjEGc5xBP0KDHgE34fv',

--- a/js/settings/staging.js
+++ b/js/settings/staging.js
@@ -4,7 +4,7 @@ const api = {
   requestApiBaseURL: 'https://stg-api.foia.gov/api',
   polydeltaProxyOrigin: 'https://stg-api.foia.gov',
   // keyof POLYDELTA_APIS in /js/util/wizard_api.js
-  polydeltaApiVersion: 'v1_1',
+  polydeltaApiVersion: 'v2_0beta',
   // These are not secret, refer to https://github.com/18F/beta.foia.gov/tree/develop/docs/foia-api.md
   apiProxyKey: 'Ear1funbgPVsgIAvRDZQK4yHq1XrLnrgfUBJM0Su',
   jsonApiKey: 'Ear1funbgPVsgIAvRDZQK4yHq1XrLnrgfUBJM0Su',

--- a/js/settings/staging.js
+++ b/js/settings/staging.js
@@ -2,7 +2,9 @@ const api = {
   localApiBaseURL: '/api',
   jsonApiBaseURL: 'https://stg-api.foia.gov/api',
   requestApiBaseURL: 'https://stg-api.foia.gov/api',
-  wizardApiURL: 'https://stg-api.foia.gov/doj-foia/models/ZBA2ow0/predict',
+  polydeltaProxyOrigin: 'https://stg-api.foia.gov',
+  // keyof POLYDELTA_APIS in /js/util/wizard_api.js
+  polydeltaApiVersion: 'v1_1',
   // These are not secret, refer to https://github.com/18F/beta.foia.gov/tree/develop/docs/foia-api.md
   apiProxyKey: 'Ear1funbgPVsgIAvRDZQK4yHq1XrLnrgfUBJM0Su',
   jsonApiKey: 'Ear1funbgPVsgIAvRDZQK4yHq1XrLnrgfUBJM0Su',

--- a/js/settings/uat.js
+++ b/js/settings/uat.js
@@ -4,7 +4,7 @@ const api = {
   requestApiBaseURL: 'https://uat-api.foia.gov/api',
   polydeltaProxyOrigin: 'https://uat-api.foia.gov',
   // keyof POLYDELTA_APIS in /js/util/wizard_api.js
-  polydeltaApiVersion: 'v1_1',
+  polydeltaApiVersion: 'v2_0beta',
   // These are not secret, refer to https://github.com/18F/beta.foia.gov/tree/develop/docs/foia-api.md
   apiProxyKey: 'PvO2Wh2UppBQqGIxIvdKbogNRI0W0MVLFhkxjWfK',
   jsonApiKey: 'PvO2Wh2UppBQqGIxIvdKbogNRI0W0MVLFhkxjWfK',

--- a/js/settings/uat.js
+++ b/js/settings/uat.js
@@ -2,7 +2,9 @@ const api = {
   localApiBaseURL: '/api',
   jsonApiBaseURL: 'https://uat-api.foia.gov/api',
   requestApiBaseURL: 'https://uat-api.foia.gov/api',
-  wizardApiURL: 'https://uat-api.foia.gov/doj-foia/models/ZBA2ow0/predict',
+  polydeltaProxyOrigin: 'https://uat-api.foia.gov',
+  // keyof POLYDELTA_APIS in /js/util/wizard_api.js
+  polydeltaApiVersion: 'v1_1',
   // These are not secret, refer to https://github.com/18F/beta.foia.gov/tree/develop/docs/foia-api.md
   apiProxyKey: 'PvO2Wh2UppBQqGIxIvdKbogNRI0W0MVLFhkxjWfK',
   jsonApiKey: 'PvO2Wh2UppBQqGIxIvdKbogNRI0W0MVLFhkxjWfK',

--- a/js/stores/wizard_store.js
+++ b/js/stores/wizard_store.js
@@ -318,10 +318,7 @@ const useRawWizardStore = create((
     if (query && !topic) {
       set({ modelLoading: true });
       await fetchWizardPredictions(query)
-        .then((data) => {
-          // Support both V1.1 and V1.0 API output.
-          const modelOutput = data.model_output || data;
-
+        .then((modelOutput) => {
           if (triggerMatch) {
             log('Collecting model results in case user chooses to switch to them.');
           } else if (trustAgencyMatch) {
@@ -382,7 +379,7 @@ const useRawWizardStore = create((
 
           // Match from finder if above threshold.
           recommendedAgencies.push(
-            ...modelOutput.agency_finder_predictions[0]
+            ...modelOutput.agency_finder_predictions
               .map(normalizeScore)
               .filter((agency) => (agency.confidence_score >= THRESHOLDS.agencyFinder)),
           );

--- a/js/util/wizard_api.js
+++ b/js/util/wizard_api.js
@@ -62,7 +62,13 @@ export function fetchWizardPredictions(query) {
         throw new Error('Polydelta response not an object');
       }
 
-      if (polydeltaApi.nestedAgencyFinder) {
+      const hasNestedAgencyFinder = Array.isArray(output.agency_finder_predictions[0]);
+      if (hasNestedAgencyFinder !== polydeltaApi.nestedAgencyFinder) {
+        // eslint-disable-next-line no-console
+        console.warn(`agency_finder_predictions is ${hasNestedAgencyFinder ? 'nested' : 'not nested'}. This doesn't match the configured API.`);
+      }
+
+      if (hasNestedAgencyFinder) {
         output.agency_finder_predictions = output.agency_finder_predictions[0];
       }
 


### PR DESCRIPTION
Allows us to handle the new polydelta APIs with better control of which URLs are used. There are no effective changes in the first commit.

TODO:

- [x] Brock adds the new proxy configuration
- [x] Set all the `polydeltaApiVersion` settings to `v2_0beta`, except production to `v2_0`